### PR TITLE
fix: adjust RangeSlider OnPanRunning behavior for MAUI 10.0.40 and above

### DIFF
--- a/PanRangeSlider/Common/MicrosoftMauiControlsVersionHelper.cs
+++ b/PanRangeSlider/Common/MicrosoftMauiControlsVersionHelper.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+
+namespace PanRangeSlider.Common
+{
+    internal static class MicrosoftMauiControlsVersionHelper
+    {
+        private static readonly Version MinMicrosoftMauiControlsVersion = new Version(10, 0, 40);
+        private static Version? _currentVersion = null;
+
+
+
+        internal static bool CanSupportsNewPanRunning()
+        {
+            return GetMauiVersion() >= MinMicrosoftMauiControlsVersion;
+        }
+
+
+
+        private static Version GetMauiVersion()
+        {
+            if (_currentVersion != null)
+                return _currentVersion;
+            
+            var assembly = typeof(View).Assembly;
+            var infoVersion = assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion;
+
+            if (Version.TryParse(infoVersion?.Split('+')[0], out var version))
+                return _currentVersion = version;
+
+            return new Version(0, 0);
+        }
+    }
+}

--- a/PanRangeSlider/Common/RangeSlider.cs
+++ b/PanRangeSlider/Common/RangeSlider.cs
@@ -1,7 +1,8 @@
-﻿using System.Runtime.CompilerServices;
-using Microsoft.Maui.Controls.Shapes;
-using static System.Math;
+﻿using Microsoft.Maui.Controls.Shapes;
+using PanRangeSlider.Common;
+using System.Runtime.CompilerServices;
 using static Microsoft.Maui.Controls.AbsoluteLayout;
+using static System.Math;
 
 namespace PanRangeSlider;
 
@@ -663,9 +664,13 @@ public class RangeSlider : TemplatedView
     }
 
     double GetPanShiftValue(View view)
-        => DeviceInfo.Platform == DevicePlatform.Android
-            ? view.TranslationX
-            : thumbPositionMap[view];
+    {
+        if (DeviceInfo.Platform != DevicePlatform.Android 
+            || MicrosoftMauiControlsVersionHelper.CanSupportsNewPanRunning())
+            return thumbPositionMap[view];
+
+        return view.TranslationX;
+    }
 
     void SetValueLabelBinding(Label label, BindableProperty bindableProperty)
         => label.SetBinding(Label.TextProperty, new Binding

--- a/PanRangeSlider/PanRangeSlider.csproj
+++ b/PanRangeSlider/PanRangeSlider.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net8.0-ios;net8.0-android;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>net10.0;net10.0-ios;net10.0-android;net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -22,7 +22,7 @@
 	    <Owners>Andrei Misiukevich</Owners>
 	    <Company>Andrei Misiukevich</Company>
 	    <NeutralLanguage>en</NeutralLanguage>
-	    <Product>RangeSlider.Maui (net8.0)</Product>
+	    <Product>RangeSlider.Maui (net10.0)</Product>
 	    <Copyright>© Andrei Misiukevich. All rights reserved.</Copyright>
 	    <PackageLicenseExpression>MIT</PackageLicenseExpression>
 	    <PackageProjectUrl>https://github.com/AndreiMisiukevich/RangeSlider.MAUI</PackageProjectUrl>
@@ -31,22 +31,18 @@
 	    <Title>RangeSlider.Maui</Title>
 	    <Description>.NET MAUI Range Slider</Description>
 	    <PackageIcon>icon.png</PackageIcon>
-	    <Version>1.0.2</Version>
+	    <Version>2.0.0</Version>
 	    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 	    <PackageTags>rangeslider, range slider, range, slider, maui</PackageTags>
 	    <Configurations>Debug;Release</Configurations>
   	</PropertyGroup>
 	
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-	</ItemGroup>
-
   	<PropertyGroup Condition="'$(Configuration)'=='Release'">
   		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
-	  <CreatePackage>false</CreatePackage>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
+		<CreatePackage>false</CreatePackage>
 	</PropertyGroup>
 	<ItemGroup>
     	<None Include="..\images\icon.png" PackagePath="icon.png" Pack="true" />

--- a/PanRangeSliderSample/PanRangeSliderSample.csproj
+++ b/PanRangeSliderSample/PanRangeSliderSample.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>PanRangeSliderSample</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -54,7 +54,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
After upgrading to .NET MAUI 10, the thumbs of the RangeSlider control move significantly faster than expected when dragging.

The issue occurs only starting from version 10.0.40 of the Microsoft.Maui.Controls library